### PR TITLE
セッション固定化攻撃脆弱性の対策

### DIFF
--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -1,4 +1,5 @@
 'use strict';
+const crypto = require('crypto');
 const jade = require('jade');
 const Cookies = require('cookies');
 const util = require('./handler-util');
@@ -7,8 +8,8 @@ const moment = require('moment-timezone');
 
 function handle(req, res){
   const cookies = new Cookies(req, res);
-  addTrackingCookie(cookies);
 
+  const trackingId = addTrackingCookie(cookies, req.user);
   switch(req.method){
     case 'GET':
       res.writeHead(200,{
@@ -32,7 +33,7 @@ function handle(req, res){
         // /postsへgetリクエストがくるたびに誰が閲覧したかログに残す
         console.info(
           `閲覧されました： user ${req.user},` +
-          `trackingId: ${cookies.get('tracking_id')},` +
+          `trackingId: ${trackingId},` +
           `remoteAddress: ${req.connection.remoteAddress},` +
           `userAgent: ${req.headers['user-agent']}`
         );
@@ -45,7 +46,7 @@ function handle(req, res){
         console.info('投稿されました: ' + content);
         Post.create({
           content: content,
-          trackingCookie: cookies.get('tracking_id'),
+          trackingCookie: trackingId,
           postedBy: req.user
         }).then(()=>{
           handleRedirectPosts(req, res);              //投稿してdb保存後は一覧へリダイレクト
@@ -96,17 +97,68 @@ function handleDelete(req, res) {
 // 認証と認可は、セキュリティ上非常に重要な機能となっており、かならずサーバー上でチェックする必要があります。
 
 
-function addTrackingCookie(cookies){
-  if(!cookies.get('tracking_id')){                                           //'tracking_id'のクッキーがブラウザになければ
-    const trackingId = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);  //ランダムな整数値を生成して
-    const tomorrow = new Date(new Date().getTime() + (1000 * 60 * 60 * 24)); //今の時刻の1日後のdateオブジェクト作って
+// function addTrackingCookie(cookies){
+//   if(!cookies.get('tracking_id')){                                           //'tracking_id'のクッキーがブラウザになければ
+//     const trackingId = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+//     const tomorrow = new Date(new Date().getTime() + (1000 * 60 * 60 * 24));
+//     //ミリ秒を渡してDateオブジェクトを生成すると、
+//     //そのミリ秒が指し示す時刻の Date オブジェクトが生成できます。
+//     //現在のミリ秒: new Date().getTime()
+//     //1 日分のミリ秒: 1000 * 60 * 60 * 24
+//     cookies.set('tracking_id', trackingId, { expires: tomorrow });           
+//   }
+// }
+
+/**
+ * Cookieに含まれているCookieに含まれているトラッキングIDに異常がなければその値を返し、
+ * 存在しない場合や異常なものである場合には、再度作成しCookieに付与してその値を返す
+ * @param {Cookies} cookies
+ * @param {String} userName
+ * @return {String} トラッキングID
+ */
+function addTrackingCookie(cookies, userName){
+  const requestedTrackingId = cookies.get('tracking_id');                        //クッキーにtracking_idがそもそもあるかどうかの判定の結果を変数に入れる
+  if(isValidTrackingId(requestedTrackingId, userName)){
+    return requestedTrackingId;                                                  //クッキーにtracking_idがあって、かつ検証も通ればそのまま返す
+  } else {                                                                       //クッキーにtracking_idがそもそもない、もしくは検証に引っかかった時。
+    //tracking_idを新規作成し、クッキーにセット
+    //tracking_idの値は(ランダムな整数値)_(ランダムな整数値 と ユーザー名 を結合したもののハッシュ値)
+    const originalId = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);      //ランダムな整数値を生成して
+    const tomorrow = new Date(new Date().getTime() + (1000 * 60 * 60 * 24));     //今の時刻の1日後のdateオブジェクト作って
     //ミリ秒を渡してDateオブジェクトを生成すると、
     //そのミリ秒が指し示す時刻の Date オブジェクトが生成できます。
     //現在のミリ秒: new Date().getTime()
     //1 日分のミリ秒: 1000 * 60 * 60 * 24
-    cookies.set('tracking_id', trackingId, { expires: tomorrow });           //'tracking_id'にランダムな整数値（有効期限は1日後）を設定
+    const trackingId = originalId + '_' + createValidHash(originalId, userName); //「ランダムな整数値」と「ランダムな整数値とユーザ名から作ったハッシュ値」からなる値を作成
+    cookies.set('tracking_id', trackingId, { expires: tomorrow });               //クッキーのtracking_idに、先ほど作成した値を設定
+    return trackingId;
   }
 }
+
+function isValidTrackingId(trackingId, userName){
+  if(!trackingId){                                                               //クッキーにtracking_idがそもそもなかった場合
+    return false;                                                                //falseを返してtracking_idを新規作成させる
+  }
+  //クッキーにtracking_idがあった場合、他ユーザーのtracking_idをハイジャックをしていない検証する
+  const splitted = trackingId.split('_');                          //1
+  const originalId = splitted[0];                                  //1
+  const requestedHash = splitted[1];                               //1
+  return createValidHash(originalId, userName) === requestedHash;  //4
+}
+
+function createValidHash(originalId, userName){
+  //ハッシュ関数にSHA-1 アルゴリズムを利用して、 元々のトラッキング ID とユーザー名を結合した文字列に対してメッセージダイジェストを作成しています。
+  //最終的にそのメッセージダイジェストを、 16 進数の文字列として返す
+  const sha1sum = crypto.createHash('sha1');
+  sha1sum.update(originalId + userName);                           //2,3
+  return sha1sum.digest('hex');
+}
+// 1) リクエストで送られた Cookie の値の「元々のトラッキング ID 」と「元々のトラッキング ID とユーザー名を結合したもののハッシュ値」を分離する
+// 2) 「元々のトラッキング ID 」と「ユーザー名」を結合した文字列をつくる
+// 3) 結合した文字列をハッシュ関数にかけて、ハッシュ値を得る
+// 4) 「送られてきたハッシュ値」と「サーバー上で生成したハッシュ値」が同じであるかを検証する。
+//    もし偽装されたものであれば、ハッシュ値が異なったり、または付与されていないものとなる
+
 
 function handleRedirectPosts(req, res){
   res.writeHead(303, {

--- a/views/posts.jade
+++ b/views/posts.jade
@@ -35,7 +35,9 @@ each post in posts
       if isPostedByAdmin
         span #{post.id} : 管理人 ★
       else
-        span #{post.id} : ID:#{post.trackingCookie}
+        //trackingidの値からハッシュ値を取り除いたもの（結果、ランダムな整数値のみになる）を用意する。
+        - var originalTrackingId = post.trackingCookie ? post.trackingCookie.split('_')[0] : ''
+        span #{post.id} : ID:#{originalTrackingId}
     div(class="panel-body")
       p(style="white-space:pre;") #{post.content}
     div(class="panel-footer")


### PR DESCRIPTION
# WHAT
クッキーのtracking_idの値を他ユーザーのものに書き換える（コンソールなどから）と他人のidになりすまして記事投稿ができてしまう状態だったので修正。
tracking_idの値をただのランダムな整数値ではなく、(ランダムな整数値)_(ランダムな整数値 と ユーザー名 を結合したもののハッシュ値)　に変更。
/postsにリクエストが飛ぶたびにtracking_idの値を偽装していないか検証する。